### PR TITLE
fix: add test dependency to allow build with API 2.12.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@
             <version>1.2.17</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Onkostar-API 2.12.x benötigt nun in den Tests eine Abhängigkeit auf:

```
<dependency>
    <groupId>org.apache.commons</groupId>
    <artifactId>commons-lang3</artifactId>
    <version>3.1</version>
    <scope>test</scope>
</dependency>
```

In Vorbereitung auf die zukünftige Verwendung der API in Version 2.12.x, wird dies hiermit aufgenommen.