### PR TITLE
chore: mark Java impl as deprecated

### DIFF
--- a/src/main/java/dev/dnpm/oshelper/services/mtb/DefaultMtbService.java
+++ b/src/main/java/dev/dnpm/oshelper/services/mtb/DefaultMtbService.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
  *
  * @since 0.0.2
  */
+@Deprecated(forRemoval = true, since = "2.1.0")
 public class DefaultMtbService implements MtbService {
 
     private final IOnkostarApi onkostarApi;

--- a/src/main/java/dev/dnpm/oshelper/services/mtb/MrMtbAnmeldungToProtocolMapper.java
+++ b/src/main/java/dev/dnpm/oshelper/services/mtb/MrMtbAnmeldungToProtocolMapper.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Optional;
 
+@Deprecated(forRemoval = true, since = "2.1.0")
 public class MrMtbAnmeldungToProtocolMapper implements ProcedureToProtocolMapper {
 
     private final IOnkostarApi onkostarApi;

--- a/src/main/java/dev/dnpm/oshelper/services/mtb/MtbService.java
+++ b/src/main/java/dev/dnpm/oshelper/services/mtb/MtbService.java
@@ -29,6 +29,7 @@ import de.itc.onkostar.api.Procedure;
 import java.util.List;
 import java.util.Optional;
 
+@Deprecated(forRemoval = true, since = "2.1.0")
 public interface MtbService {
     /**
      * Zusammenfassung der Prozeduren

--- a/src/main/java/dev/dnpm/oshelper/services/mtb/OsTumorkonferenzToProtocolMapper.java
+++ b/src/main/java/dev/dnpm/oshelper/services/mtb/OsTumorkonferenzToProtocolMapper.java
@@ -34,6 +34,7 @@ import java.util.Optional;
  *
  * @since 0.0.2
  */
+@Deprecated(forRemoval = true, since = "2.1.0")
 public class OsTumorkonferenzToProtocolMapper implements ProcedureToProtocolMapper {
 
     /**

--- a/src/main/java/dev/dnpm/oshelper/services/mtb/OsTumorkonferenzVarianteUkwToProtocolMapper.java
+++ b/src/main/java/dev/dnpm/oshelper/services/mtb/OsTumorkonferenzVarianteUkwToProtocolMapper.java
@@ -33,6 +33,7 @@ import java.util.Optional;
  *
  * @since 0.0.2
  */
+@Deprecated(forRemoval = true, since = "2.1.0")
 public class OsTumorkonferenzVarianteUkwToProtocolMapper implements ProcedureToProtocolMapper {
 
     /**

--- a/src/main/java/dev/dnpm/oshelper/services/mtb/ProcedureToProtocolMapper.java
+++ b/src/main/java/dev/dnpm/oshelper/services/mtb/ProcedureToProtocolMapper.java
@@ -29,5 +29,6 @@ import de.itc.onkostar.api.Procedure;
 import java.util.Optional;
 import java.util.function.Function;
 
+@Deprecated(forRemoval = true, since = "2.1.0")
 @FunctionalInterface
 public interface ProcedureToProtocolMapper extends Function<Procedure, Optional<String>> {}


### PR DESCRIPTION
These services will be removed due to required changes in documentation with single MTB per care plan.

Selection of description will be replaced by simple form script on MTB selection.